### PR TITLE
Fix stats.sh for POSIX sh

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -15,12 +15,17 @@ for filename in dist/*.txt; do
   base_filename=${base_filename%.txt}
   
   # Skip if filter is provided and doesn't match the filename
-  if [ "$filter" != "" ] && [[ "$base_filename" != *"$filter"* ]]; then
-    continue
+  if [ "$filter" != "" ]; then
+    case "$base_filename" in
+      *"$filter"*) : ;;
+      *)
+        continue
+        ;;
+    esac
   fi
 
   slidecount=$(cat ${filename} | grep -- "---" | wc -w |tr -d '[:blank:]')
-  ((slidecount++))
+  slidecount=$((slidecount + 1))
   if [ "$slidecount" -eq 1 ]; then
     continue
   fi


### PR DESCRIPTION
## Summary
- update stats.sh to avoid bashisms
- use case pattern matching
- increment slidecount with POSIX arithmetic

## Testing
- `sh ./stats.sh` *(fails: `cat: 'dist/*.txt': No such file or directory`, `column: not found`)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68401a8de914832a96d0a42e6e07256e