### PR TITLE
Fix invalid main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "talks",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "type": "module",
   "scripts": {
     "lint": "prettier --check .",


### PR DESCRIPTION
## Summary
- remove the unused `main` field from package.json

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68401a994658832ab9fdc9ccb8c69ed0