### PR TITLE
Fix stats script for efficiency

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -22,12 +22,12 @@ for filename in dist/*.txt; do
     esac
   fi
 
-  slidecount=$(cat ${filename} | grep -- "---" | wc -w |tr -d '[:blank:]')
+  slidecount=$(grep -- "---" "$filename" | wc -w | tr -d '[:blank:]')
   ((slidecount++))
   if [ "$slidecount" -eq 1 ]; then
     continue
   fi
-  wordcount=$(cat ${filename} | grep -v -- "---" | wc -w| tr -d '[:blank:]')
+  wordcount=$(grep -v -- "---" "$filename" | wc -w | tr -d '[:blank:]')
   minutes=$(echo "scale=2; $wordcount / $words_per_minute" | bc)
 
   filename=${filename#dist/}


### PR DESCRIPTION
## Summary
- avoid UUOC in `stats.sh`

## Testing
- `npm run lint`
- `npm run build:txt` *(fails: No suitable browser found)*

------
https://chatgpt.com/codex/tasks/task_e_68401a9229a8832aa8873c439ea58332