### PR TITLE
fix: make stats.sh portable

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -15,8 +15,11 @@ for filename in dist/*.txt; do
   base_filename=${base_filename%.txt}
   
   # Skip if filter is provided and doesn't match the filename
-  if [ "$filter" != "" ] && [[ "$base_filename" != *"$filter"* ]]; then
-    continue
+  if [ "$filter" != "" ]; then
+    case "$base_filename" in
+      *"$filter"*) ;;
+      *) continue ;;
+    esac
   fi
 
   slidecount=$(cat ${filename} | grep -- "---" | wc -w |tr -d '[:blank:]')


### PR DESCRIPTION
## Summary
- update filename filter logic in `stats.sh` to use POSIX sh features

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68401e7eabd0832a8a35ce1519a1dc5f