### PR TITLE
Fix schedule rendering in index generator

### DIFF
--- a/__tests__/generate_index.test.js
+++ b/__tests__/generate_index.test.js
@@ -26,4 +26,6 @@ test("index generation includes headings", () => {
   const html = output.toString();
   expect(html).toContain("Upcoming talks");
   expect(html).toContain("Previous talks");
+  expect(html).not.toContain("[object Object]");
+  expect(html).not.toContain("undefined</table>");
 });

--- a/generate_index.js
+++ b/generate_index.js
@@ -27,20 +27,37 @@ let scheduleSelect = "future";
 const schedule = fs.readFileSync("schedule.md", "utf8");
 
 const renderer = {
-  table(header, body) {
-    return `<table class="table table-striped table-sm">
-<thead class="thead-dark">${header}</thead>
-${body}
-</table>`;
+  /**
+   * Marked >=15 passes a single token to `table`. Recreate the default
+   * rendering logic and apply our custom classes.
+   */
+  table(token) {
+    let header = "";
+    let cell = "";
+    for (let j = 0; j < token.header.length; j++) {
+      cell += this.tablecell(token.header[j]);
+    }
+    header += this.tablerow({ text: cell });
+    let body = "";
+    for (let j = 0; j < token.rows.length; j++) {
+      const row = token.rows[j];
+      cell = "";
+      for (let k = 0; k < row.length; k++) {
+        cell += this.tablecell(row[k]);
+      }
+      body += this.tablerow({ text: cell });
+    }
+    if (body) body = `<tbody>${body}</tbody>`;
+    return `<table class="table table-striped table-sm">\n<thead class="thead-dark">${header}</thead>\n${body}</table>\n`;
   },
-  tablerow(content) {
-    const date = (content.match(/\d{4}-\d{2}-\d{2}/g) || [])[0];
+  tablerow({ text }) {
+    const date = (text.match(/\d{4}-\d{2}-\d{2}/g) || [])[0];
     if (
       date === undefined ||
       (scheduleSelect === "future" && date && Date.parse(date) > Date.now()) ||
       (scheduleSelect === "past" && date && Date.parse(date) < Date.now())
     )
-      return `<tr>\n${content}</tr>\n`;
+      return `<tr>\n${text}</tr>\n`;
     return "";
   },
 };


### PR DESCRIPTION
## Summary
- update table renderer in `generate_index.js` for marked v15
- ensure tests verify schedule output doesn't contain `[object Object]`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848478ebf28832aaf96b9fcab1f3769