### PR TITLE
fix: pin postcss@^8 and quiet git-secret watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "secrets:reveal": "git secret reveal",
     "server:postcss": "postcss --watch --ext css -d themes themes",
     "server:marp": "marp -s",
-    "server:git-secret": "while true; do npm run secrets:hide > /dev/null; sleep 1; done",
+    "server:git-secret": "while true; do npm run secrets:hide > /dev/null 2>&1; sleep 1; done",
     "prepare": "husky"
   },
   "author": "Chris Nesbitt-Smith",
@@ -34,6 +34,7 @@
     "husky": "^9.0.11",
     "marked": "^18.0.0",
     "npm-run-all2": "8.0.4",
+    "postcss": "^8.5.6",
     "postcss-cli": "11.0.1",
     "postcss-discard-comments": "^7.0.0",
     "postcss-for": "^2.1.1",


### PR DESCRIPTION
## Summary
- Add `postcss@^8.5.6` as a direct dep so yarn hoists v8 to top level instead of the v5 dragged in by `postcss-use`. `postcss-cli@11` needs v8 as a peer, and on v5 the new-style plugin creators (`creator.postcss = true`) blow up with `Error: true is not a PostCSS plugin`, breaking `yarn start`.
- Redirect stderr in the `server:git-secret` watch loop so contributors without the git-secret key don't get a flood of `abort: file not found` lines on every iteration.

## Test plan
- [ ] `yarn install`
- [ ] `yarn start` boots Marp on http://localhost:8080 with no PostCSS errors
- [ ] No `git-secret: abort: file not found` noise in the output (with or without revealed secrets)