### PR TITLE
Fix Security Scanning workflow permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,4 +10,6 @@ jobs:
     uses: chrisns/.github/.github/workflows/security-scan.yml@main
     permissions:
       security-events: write
+      contents: read
+      actions: read
       statuses: write


### PR DESCRIPTION
## Summary
The reusable workflow `chrisns/.github/.github/workflows/security-scan.yml@main` requires `contents: read` and `actions: read` for CodeQL's checkout and analysis steps. The caller in this repo only granted `security-events: write` and `statuses: write`, so the workflow failed at startup on every run with:

> The nested job 'CodeQL' is requesting 'actions: read, contents: read', but is only allowed 'actions: none, contents: none'.

Added the two missing read permissions.

## Test plan
- [ ] Security Scanning workflow starts (no longer startup_failure) on this PR