### PR TITLE
chore: reformat for prettier 3.9.6

### DIFF
--- a/nginx-livedemo/script.md
+++ b/nginx-livedemo/script.md
@@ -107,10 +107,10 @@ http://localhost/product/<iframe width='560' height='315' src='https://www.youtu
 helm repo add nginx-stable https://helm.nginx.com/stable
 
 helm install main nginx-stable/nginx-ingress \
- --set controller.enableSnippets=true \
- --set controller.image.pullPolicy=Never \
- --set controller.service.type=NodePort \
- --set controller.service.httpPort.nodePort=30000
+--set controller.enableSnippets=true \
+--set controller.image.pullPolicy=Never \
+--set controller.service.type=NodePort \
+--set controller.service.httpPort.nodePort=30000
 
 ```
 

--- a/nginx.md
+++ b/nginx.md
@@ -278,6 +278,7 @@ but however it happens because of the HTTP protocol you're limited to a number o
 - PATCH
 - DELETE
 - ETC
+
 <!--
 Theres some obvious methods, but really they're arbitrary stings we agree on with expected behavior
 -->


### PR DESCRIPTION
CI lint is failing on `main`: the prettier bump to 3.9.6 (#681 lockfile maintenance) changed formatting for two files that were never reformatted.

`npx prettier@3.9.6 --write` on the two offenders. No content changes.

https://claude.ai/code/session_019nj2rsnYHr9hNXqM7wARa6